### PR TITLE
[fix] Broken link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,9 @@
-# Website
+# Wanny's Blog
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+## About
 
-### Installation
+이 웹사이트는 [Docusaurus 2](https://docusaurus.io/)로 만들어졌습니다.
 
-```
-$ yarn
-```
+## Tutorial
 
-### Local Development
-
-```
-$ yarn start
-```
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-```
-$ yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+직접 만들어보고 싶다면 [Docusaurus 시작하기](https://0420syj.github.io/docs/docusaurus-tutorial/intro)를 참고하세요.

--- a/docs/docusaurus-tutorial/_category_.json
+++ b/docs/docusaurus-tutorial/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Docusaurus Blog Tutorial",
+  "label": "Docusaurus 블로그 만들기",
   "position": 2,
   "link": {
     "type": "generated-index"

--- a/docs/docusaurus-tutorial/_category_.json
+++ b/docs/docusaurus-tutorial/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Docusaurus 블로그 만들기",
+  "label": "Docusaurus Blog Tutorial",
   "position": 2,
   "link": {
     "type": "generated-index"

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,4 +18,4 @@ sidebar_position: 1
 
 ## 어떤 **Tutorial**이 있나요?
 
-- [Docusaurus 블로그 만들기](category/docusarus-튜토리얼)
+- [Docusaurus 블로그 만들기](category/docusaurus-블로그-만들기)


### PR DESCRIPTION
```json
{
  "label": "Docusaurus Blog Tutorial",
  "position": 2,
  "link": {
    "type": "generated-index"
  }
}
```

위와 같이 `generated-index`를 사용하는 경우, 한글로 label명을 지을 수 업는 것으로 추측됨